### PR TITLE
Organized package imports

### DIFF
--- a/ActionBarPlugin.java
+++ b/ActionBarPlugin.java
@@ -43,8 +43,8 @@ import android.widget.LinearLayout.LayoutParams;
 import android.widget.SpinnerAdapter;
 import android.widget.TextView;
 
-import org.apache.cordova.api.CallbackContext;
-import org.apache.cordova.api.CordovaPlugin;
+import org.apache.cordova.CallbackContext;
+import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;


### PR DESCRIPTION
The package "org.apache.cordova.api.CallbackContext" has been replaced with "org.apache.cordova.CallbackContext" in cordova version 4.0.x. Same goes for "org.apache.cordova.api.CordovaPlugin", replaced with "org.apache.cordova.CordovaPlugin".

Thanks